### PR TITLE
[voicecall] Fix crash when active voice call ends.

### DIFF
--- a/src/voicecallmanager.cpp
+++ b/src/voicecallmanager.cpp
@@ -348,7 +348,7 @@ void VoiceCallManager::onVoiceCallRemoved(const QString &handlerId)
     emit this->voiceCallRemoved(handlerId);
     emit this->voiceCallsChanged();
 
-    if(d->activeVoiceCall->handlerId() == handlerId)
+    if (d->activeVoiceCall && d->activeVoiceCall->handlerId() == handlerId)
     {
         d->activeVoiceCall = NULL;
         emit this->activeVoiceCallChanged();


### PR DESCRIPTION
Fix a null pointer dereference which occurs when the
onVoiceCallRemoved() slots is called multiple times in quick
succession, from different providers.
