### PR TITLE
Revert "[voicecall] Remove pulseaudio and resource policy plugins."

### DIFF
--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -6,4 +6,4 @@ TEMPLATE = subdirs
 #
 # Qt 5's voiceall needs all plugins.
 equals(QT_MAJOR_VERSION, 4): SUBDIRS = declarative
-equals(QT_MAJOR_VERSION, 5): SUBDIRS = declarative providers ngf playback-manager
+equals(QT_MAJOR_VERSION, 5): SUBDIRS = declarative pulseaudio providers resource-policy-routing ngf playback-manager

--- a/plugins/pulseaudio/modes.ini
+++ b/plugins/pulseaudio/modes.ini
@@ -1,0 +1,61 @@
+[.global]
+source = source.voice
+sink   = sink.voice
+
+[.default]
+input        = source.hw0
+input-port   = nokia-n950-twl-4030-input-internal-microphones
+input-source = source.hw0
+output       = sink.hw0
+output-port  = nokia-n950-twl4030-output-earpiece
+output-sink  = sink.headphone
+
+[earpiece]
+input        = source.hw0
+input-port   = nokia-n950-twl4030-input-internal-microphones
+input-source = source.hw0
+output       = sink.hw0
+output-port  = nokia-n950-twl4030-output-earpiece
+output-sink  = sink.headphone
+
+[headset]
+input        = source.hw0
+input-port   = nokia-n950-twl4030-input-headset
+input-source = source.hw0
+output       = sink.hw0
+ourput-port  = nokia-n950-twl4030-output-headset
+output-sink  = sink.headphone
+
+[ihf]
+input        = source.hw0
+input-port   = nokia-n950-twl4030-input-internal-microphones
+input-source = source.hw0
+output       = sink.hw0
+output-port  = nokia-n950-twl4030-output-ihf
+output-sink  = sink.headphone
+
+; Bluetooth is harder, need to use hw0 if analog, and hw1 if digital.
+;(two modes, sco and a2dp maybe?)
+[bt-sco]
+input        = source.hw1
+input-port   = nokia-n950-wl1273-input-bt
+input-source = source.hw0
+output       = sink.hw1
+output-port  = nokia-n950-wl1273-output-bt
+output-sink  = sink.hw0
+
+[bt-a2dp]
+input        = source.hw1
+input-port   = nokia-n950-wl1273-input-bt
+input-source = source.hw1
+output       = sink.hw1
+output-port  = nokia-n950-wl1273-output-bt
+output-sink  = sink.headphone
+
+[fmrxtx]
+input        = source.hw1
+input-port   = nokia-n950-wl1273-input-fmrx
+input-source = source.hw0
+output       = sink.hw1
+output-port  = nokia-n950-wl1273-output-fmtx
+output-sink  = sink.headphone

--- a/plugins/pulseaudio/pulseaudio.pro
+++ b/plugins/pulseaudio/pulseaudio.pro
@@ -1,0 +1,9 @@
+TEMPLATE = subdirs
+SUBDIRS = src
+
+OTHER_FILES += LICENSE modes.ini
+
+config.files = modes.ini
+config.path = /etc/voicecall/
+
+INSTALLS += config

--- a/plugins/pulseaudio/src/pacontrol.cpp
+++ b/plugins/pulseaudio/src/pacontrol.cpp
@@ -1,0 +1,745 @@
+/*
+ * hfdialer - Hands Free Voice Call Manager
+ * Copyright (c) 2012, Intel Corporation.
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+#include "common.h"
+#include "pacontrol.h"
+#include <string.h>
+#include <QStringBuilder>
+#include <QList>
+#include <QDebug>
+#include <QTimer>
+
+// Define our pulse audio loop and connection variables
+static PAControl* paControl = NULL;
+// Create a mainloop API and connection to the default server
+static pa_glib_mainloop *pa_ml = NULL;
+
+static void pa_subscribed_events_cb(pa_context *c, enum pa_subscription_event_type t, uint32_t , void *);
+
+static void operation_callback(pa_context *c, int success, void *userdata)
+{
+    Q_UNUSED(c);
+    Q_UNUSED(userdata);
+
+    if (!success)
+    {
+        DEBUG_T(QString("Operation Failed"));
+        paControl->setErrorMsg(QString("Operation Failed"));
+    }
+}
+
+static void module_callback(pa_context *c, uint32_t index, void *userdata)
+{
+    Q_UNUSED(c);
+    Q_UNUSED(userdata);
+    if (index == PA_INVALID_INDEX)
+    {
+        DEBUG_T(QString("Load module failed"));
+        paControl->setErrorMsg(QString("Load module failed"));
+    }
+}
+
+static void pa_sourcelist_cb(pa_context *c,
+                             const pa_source_info *l,
+                             int is_last,
+                             void *userdata)
+{
+    Q_UNUSED(c);
+    Q_UNUSED(userdata);
+    PADevice *source;
+
+    if (is_last > 0)
+    {
+        //end of the list
+        paControl->release();
+        return;
+    }
+
+    //DEBUG_T(QString("pa_sourcelist_cb() Source added: ") + l->name);
+    source = new PADevice();
+    source->index = l->index;
+    if(l->name != NULL)
+        source->name = l->name;
+    if(l->description != NULL)
+        source->description = l->description;
+    paControl->addSource(source);
+}
+
+static void pa_sinklist_cb(pa_context *c,
+                           const pa_sink_info *l,
+                           int is_last,
+                           void *userdata)
+{
+    Q_UNUSED(c);
+    Q_UNUSED(userdata);
+    PADevice *sink;
+
+    if (is_last > 0)
+    {
+        //end of the list
+        paControl->release();
+        return;
+    }
+
+    sink = new PADevice();
+    sink->index = l->index;
+    if(l->name != NULL)
+        sink->name = l->name;
+    if(l->description != NULL)
+        sink->description = l->description;
+    paControl->addSink(sink);
+}
+
+static void pa_modulelist_cb(pa_context *c,
+                             const pa_module_info *i,
+                             int is_last,
+                             void *userdata)
+{
+    Q_UNUSED(c);
+    Q_UNUSED(userdata);
+    PAModule *module;
+
+    if (is_last > 0)
+    {
+        //end of the list
+        paControl->release();
+        return;
+    }
+
+    module = new PAModule();
+    module->index = i->index;
+    if(i->name != NULL)
+        module->name = i->name;
+    if(i->argument != NULL)
+        module->arguments = i->argument;
+    paControl->addModule(module);
+}
+
+static void pa_state_cb(pa_context *c, void *)
+{
+    pa_context_state_t state = pa_context_get_state(c);
+    if(state == PA_CONTEXT_READY)
+    {
+        paControl->setState(true);
+        pa_context_set_subscribe_callback(c, pa_subscribed_events_cb, NULL);
+        pa_operation *o;
+        if (!(o = pa_context_subscribe(c, (pa_subscription_mask_t)
+                                       (PA_SUBSCRIPTION_MASK_MODULE|
+                                        PA_SUBSCRIPTION_MASK_SINK|
+                                        PA_SUBSCRIPTION_MASK_SOURCE|
+                                        PA_SUBSCRIPTION_MASK_SINK_INPUT|
+                                        PA_SUBSCRIPTION_MASK_SOURCE_OUTPUT), NULL, NULL))) {
+            WARNING_T("pa_context_subscribe() failed");
+        }
+        if(o) pa_operation_unref(o);
+        ///Get an initial list of sinks, sources and modules.
+        paControl->addRef();
+        pa_context_get_sink_info_list(c, pa_sinklist_cb, NULL);
+        paControl->addRef();
+        pa_context_get_source_info_list(c, pa_sourcelist_cb, NULL);
+        paControl->addRef();
+        pa_context_get_module_info_list(c, pa_modulelist_cb, NULL);
+    }
+    else if(state == PA_CONTEXT_FAILED)
+    {
+        ///Pulseaudio crashed?
+        paControl->setState(false);
+    }
+    else
+    {
+        DEBUG_T(QString("PA state: ") + (int)state);
+    }
+}
+
+static void pa_subscribed_events_cb(pa_context *c, enum pa_subscription_event_type t, uint32_t , void *)
+{
+    switch (t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK)
+    {
+    case PA_SUBSCRIPTION_EVENT_SINK:
+        //DEBUG_T("PA_SUBSCRIPTION_EVENT_SINK event triggered");
+        foreach(PADevice* dev, paControl->sinkList)
+        {
+            delete dev;
+        }
+        paControl->sinkList.clear();
+        paControl->addRef();
+        pa_context_get_sink_info_list(c, pa_sinklist_cb, NULL);
+        break;
+    case PA_SUBSCRIPTION_EVENT_SOURCE:
+        //DEBUG_T("PA_SUBSCRIPTION_EVENT_SOURCE event triggered");
+        foreach(PADevice* dev, paControl->sourceList)
+        {
+            delete dev;
+        }
+        paControl->sourceList.clear();
+        paControl->addRef();
+        pa_context_get_source_info_list(c, pa_sourcelist_cb, NULL);
+        break;
+    case PA_SUBSCRIPTION_EVENT_MODULE:
+        //DEBUG_T("PA_SUBSCRIPTION_EVENT_MODULE event triggered");
+        foreach(PAModule* dev, paControl->moduleList)
+        {
+            delete dev;
+        }
+        paControl->moduleList.clear();
+        paControl->addRef();
+        pa_context_get_module_info_list(c, pa_modulelist_cb, NULL);
+        break;
+    }
+}
+
+PAControl::PAControl(VoiceCallManagerInterface *manager, QObject *parent)
+    : QObject(parent)
+{
+    m_manager = manager;
+    source = NULL;
+    sink = NULL;
+    input = NULL;
+    output = NULL;
+    status = SUCCESS;
+    m_paState = false;
+    m_isInitialized = false;
+
+    this->paInit();
+}
+
+PAControl::~PAControl()
+{
+    paCleanup();
+
+    foreach (PADevice *source, sourceList)
+    {
+        DEBUG_T("delete source");
+        delete source;
+    }
+    foreach (PADevice *sink, sinkList)
+    {
+        DEBUG_T("delete sink");
+        delete sink;
+    }
+    foreach (PAModule *module, moduleList)
+    {
+        DEBUG_T("delete module");
+        delete module;
+    }
+
+    DEBUG_T("~PAControl()");
+    paControl = NULL;
+}
+
+PAControl* PAControl::instance(VoiceCallManagerInterface *manager)
+{
+    if(!paControl) paControl = new PAControl(manager);
+    return paControl;
+}
+
+void PAControl::paInit()
+{
+    DEBUG_T("paInit()");
+
+    // Create a mainloop API and connection to the default server
+    if(!pa_ml) pa_ml = pa_glib_mainloop_new(NULL);
+
+    pa_ctx = pa_context_new(pa_glib_mainloop_get_api(pa_ml),
+                            "org.nemomobile.voicecall");
+
+    // This function connects to the pulse server
+    if (pa_context_connect(pa_ctx,
+                           NULL,
+                           PA_CONTEXT_NOFAIL, NULL) < 0)
+    {
+        qCritical("PulseAudioService: pa_context_connect() failed");
+        paCleanup();
+        return;
+    }
+
+    m_refCounter = 0;
+    m_connected = false;
+    m_audioRouted = false;
+    m_btSourceReady =false;
+    m_btSinkReady = false;
+    m_isInitialized = true;
+
+    pa_context_set_state_callback(pa_ctx, pa_state_cb, NULL);
+}
+
+void PAControl::paCleanup()
+{
+    DEBUG_T("paCleanup()");
+    if(pa_ctx)
+        pa_context_disconnect(pa_ctx);
+    if(pa_ctx)
+        pa_context_unref(pa_ctx);
+}
+
+void PAControl::setState(bool state)
+{
+    m_paState = state;
+    if(state == false)
+    {
+        emit paFailed();
+    }
+}
+
+void PAControl::addRef()
+{
+    m_refCounter++;
+}
+
+void PAControl::release()
+{
+    m_refCounter--;
+    Q_ASSERT(m_refCounter >= 0);
+}
+
+void PAControl::reconnect()
+{
+    DEBUG_T("Pulseaudio: reconnect()");
+    if(paControl)
+        delete paControl;
+    paControl = new PAControl(m_manager);
+}
+
+
+
+PADevice* PAControl::findBluezSource()
+{
+    if (sourceList.size() == 0)
+    {
+        addRef();
+        pa_op = pa_context_get_source_info_list(pa_ctx, pa_sourcelist_cb, NULL);
+        if(pa_op) pa_operation_unref(pa_op);
+
+        return NULL;
+    }
+
+    foreach (PADevice *source, sourceList)
+    {
+        QString name = source->name;
+
+        if (name.startsWith(QString("bluez_source."), Qt::CaseSensitive))
+        {
+            DEBUG_T(QString("   Matched Bluez source: ") + name);
+            return source;
+        }
+    }
+
+    DEBUG_T("Bluez source: none found");
+    return NULL;
+}
+
+PADevice*  PAControl::findBluezSink()
+{
+    if (sinkList.size() == 0)
+    {
+        addRef();
+        pa_op = pa_context_get_sink_info_list(pa_ctx, pa_sinklist_cb, NULL);
+        if(pa_op) pa_operation_unref(pa_op);
+
+        return NULL;
+    }
+
+    foreach (PADevice *sink, sinkList)
+    {
+        QString name = sink->name;
+
+        if (name.startsWith(QString("bluez_sink."), Qt::CaseSensitive))
+        {
+            DEBUG_T(QString("   Matched Bluez sink: ") + name);
+            return sink;
+        }
+    }
+
+    DEBUG_T("Bluez sink: none found");
+    return NULL;
+}
+
+PADevice* PAControl::findAlsaSource(QString alsasource)
+{
+    if (sourceList.size() == 0)
+    {
+        addRef();
+        pa_op = pa_context_get_source_info_list(pa_ctx, pa_sourcelist_cb, NULL);
+        if(pa_op) pa_operation_unref(pa_op);
+
+        return NULL;
+    }
+
+    foreach (PADevice *source, sourceList)
+    {
+        DEBUG_T(QString("Alsa source: ") + source->name);
+        QString name = source->name;
+
+        if (!alsasource.isNull() && !alsasource.isEmpty())
+        {
+            // if alsa source name is provided
+            if (alsasource == name)
+            {
+                DEBUG_T(QString("   Matched Alsa source: ") + name);
+                return source;
+            }
+        } else if (name.startsWith(QString("alsa_input."), Qt::CaseSensitive) &&
+                   name.endsWith(QString("analog-stereo"), Qt::CaseSensitive) &&
+                   !name.contains(QString("timb")))
+        {
+            // this is default behavior, it will try to look up one
+            DEBUG_T(QString("   Matched Alsa source: ") + name);
+            return source;
+        }
+    }
+
+    DEBUG_T("Alsa source: none found");
+    return NULL;
+}
+
+PADevice*  PAControl::findAlsaSink(QString alsasink)
+{
+    if (sinkList.size() == 0)
+    {
+        addRef();
+        pa_op = pa_context_get_sink_info_list(pa_ctx, pa_sinklist_cb, NULL);
+        if(pa_op) pa_operation_unref(pa_op);
+
+        return NULL;
+    }
+
+    foreach (PADevice *sink, sinkList)
+    {
+        DEBUG_T(QString("Alsa sink: ") + sink->name);
+        QString name = sink->name;
+
+        if (!alsasink.isNull() && !alsasink.isEmpty())
+        {
+            // if alsa sink name is provided
+            if (alsasink == name)
+            {
+                DEBUG_T(QString("   Matched Alsa sink: ") + name);
+                return sink;
+            }
+        } else if (name.startsWith(QString("alsa_output."), Qt::CaseSensitive) &&
+                   name.endsWith(QString("analog-stereo"), Qt::CaseSensitive) &&
+                   !name.contains(QString("timb")))
+        {
+            // this is default behavior, it will try to look up one
+            DEBUG_T(QString("   Matched Alsa sink: ") + name);
+            return sink;
+        }
+    }
+
+    DEBUG_T("Alsa sink: none found");
+    return NULL;
+}
+
+PAModule* PAControl::findModule(QString name, QString pattern)
+{
+    if (moduleList.size() == 0)
+    {
+        addRef();
+        pa_op = pa_context_get_module_info_list(pa_ctx, pa_modulelist_cb, NULL);
+        if(pa_op) pa_operation_unref(pa_op);
+
+        return NULL;
+    }
+
+    foreach (PAModule *module, moduleList)
+    {
+        if (module->name.contains(name) && module->arguments.contains(pattern))
+        {
+            DEBUG_T(QString("   Matched module: ") + module->name);
+            DEBUG_T(QString("   argument: ") + module->arguments);
+            return module;
+        }
+    }
+
+    DEBUG_T("Module: none found");
+    return NULL;
+}
+
+QList<PAModule*> PAControl::getAllModules()
+{
+    if (moduleList.size() == 0)
+    {
+        addRef();
+        pa_op = pa_context_get_module_info_list(pa_ctx, pa_modulelist_cb, NULL);
+        if(pa_op) pa_operation_unref(pa_op);
+    }
+
+    return moduleList;
+}
+
+void PAControl::addSource(PADevice* device)
+{
+    foreach(PADevice* dev, sourceList)
+    {
+        if(dev->name == device->name)
+        {
+            delete device;
+            return; /// already exists
+        }
+    }
+
+    sourceList.append(device);
+    emit sourceAppeared(device);
+}
+
+void PAControl::addSink(PADevice* device)
+{
+    foreach(PADevice* dev, sinkList)
+    {
+        if(dev->name == device->name)
+        {
+            delete device;
+            return; /// already exists
+        }
+    }
+
+    sinkList.append(device);
+    emit sinkAppeared(device);
+}
+
+void PAControl::addModule(PAModule *module)
+{
+    foreach(PAModule* dev, moduleList)
+    {
+        if(dev->name == module->name && dev->index == module->index)
+        {
+            delete module;
+            return; /// already exists
+        }
+    }
+
+    moduleList.append(module);
+    emit moduleAppeared(module);
+}
+
+void PAControl::setSourcePortByName(PADevice *source, const QString &port)
+{
+    DEBUG_T(QString("Setting source ") + source->name + " port to " + port);
+    if(!source) return;
+
+    pa_op = pa_context_set_source_port_by_name(pa_ctx, source->name.toLatin1(), port.toLatin1(), operation_callback, NULL);
+    if(pa_op) pa_operation_unref(pa_op);
+}
+
+void PAControl::setSinkPortByName(PADevice *sink, const QString &port)
+{
+    DEBUG_T(QString("Setting sink ") + sink->name + " port to " + port);
+    if(!source) return;
+
+    pa_op = pa_context_set_sink_port_by_name(pa_ctx, sink->name.toLatin1(), port.toLatin1(), operation_callback, NULL);
+    if(pa_op) pa_operation_unref(pa_op);
+}
+
+void PAControl::routeSourceWithSink(PADevice *source, PADevice *sink)
+{
+    DEBUG_T(QString("Routing from ") + source->name + " to " + sink->name);
+
+    if (source != NULL && sink != NULL)
+    {
+        QString arg = "source=\"" % source->name % "\" sink=\"" % sink->name % "\"";
+
+        pa_op = pa_context_load_module(pa_ctx, "module-loopback", arg.toLatin1().data(), module_callback, NULL);
+        if(pa_op) pa_operation_unref(pa_op);
+
+        DEBUG_T(QString("load-module module-loopback ") + arg);
+    }
+}
+
+void PAControl::toggleMuteSink(PADevice *sink, bool isMute)
+{
+    if (sink != NULL)
+    {
+        pa_op = pa_context_set_sink_mute_by_name(pa_ctx, sink->name.toLatin1().data(), isMute, operation_callback, NULL);
+        if(pa_op) pa_operation_unref(pa_op);
+
+        DEBUG_T(QString("set sink mute ") + sink->name + QString(" to ") + isMute);
+    }
+}
+
+void PAControl::toggleMuteSource(PADevice *source, bool isMute)
+{
+    if (source != NULL)
+    {
+        pa_op =pa_context_set_source_mute_by_name(pa_ctx, source->name.toLatin1().data(), isMute, operation_callback, NULL);
+        if(pa_op) pa_operation_unref(pa_op);
+
+        DEBUG_T(QString("set source mute ") + source->name + QString(" to ") + isMute);
+    }
+}
+
+void  PAControl::unloadModule(PAModule* module)
+{
+    if (module != NULL && module->index >= 0)
+    {
+        pa_op = pa_context_unload_module(pa_ctx, module->index, operation_callback, NULL);
+        if(pa_op) pa_operation_unref(pa_op);
+        DEBUG_T(QString("unload-module module-loopback ") +  QString(module->name) + QString(" at index ") + module->index);
+    }
+}
+
+PAStatus PAControl::getStatus()
+{
+    return this->status;
+}
+
+void PAControl::setErrorMsg(QString msg)
+{
+    if (msg != NULL)
+    {
+        this->status = ERROR;
+        this->errorMsg = msg;
+    }
+}
+
+QString PAControl::getErrorMsg()
+{
+    return this->errorMsg;
+}
+
+void PAControl::routeAudio()
+{
+    if (m_refCounter > 0)
+    {
+        DEBUG_T("PA callback not finished, scheduling retry.");
+        QTimer::singleShot(250, this, SLOT(routeAudio()));
+        return;
+    }
+
+    // Setup port depending on current policy.
+    this->setSourcePortByName(input, input_port);
+    this->setSinkPortByName(output, output_port);
+
+    /*
+    // Hook up sources and sinks.
+    this->routeSourceWithSink(source, output_sink);
+    this->routeSourceWithSink(input_source, sink);
+    */
+
+    m_audioRouted = true;
+
+    disconnect(this, SIGNAL(sourceAppeared(PADevice*)));
+    disconnect(this, SIGNAL(sinkAppeared(PADevice*)));
+}
+
+void PAControl::unrouteAudio()
+{
+    /*
+    QList<PAModule*> mlist = this->getAllModules();
+    foreach(PAModule *module, mlist)
+    {
+        if (module->name.contains("module-loopback") &&
+            module->arguments.contains("bluez") &&
+            module->arguments.contains("alsa")) {
+            DEBUG_T(QString("Found loopback module, index: ") + module->index);
+            paControl->unloadModule(module);
+            DEBUG_T("Remove loopback module successful");
+        }
+    }
+    */
+
+    m_audioRouted = false;
+    m_btSourceReady = false;
+    m_btSinkReady = false;
+}
+
+void PAControl::onSourceAppeared(PADevice* device)
+{
+    if(m_manager->voiceCallCount() == 0)
+    {
+        DEBUG_T("no calls active, ignore");
+        return;
+    }
+
+    if(device->name.contains("bluez_source"))
+    {
+        m_btSourceReady = true;
+    }
+
+    if(!m_audioRouted && m_btSourceReady && m_btSinkReady)
+    {
+        DEBUG_T("Route microphone and speakers");
+        //routeAudio();
+    }
+}
+
+void PAControl::onSinkAppeared(PADevice* device)
+{
+    if(m_manager->voiceCallCount() == 0)
+    {
+        DEBUG_T("no calls active, ignore");
+        return;
+    }
+
+    if((device)->name.contains("bluez_sink"))
+    {
+        m_btSinkReady = true;
+    }
+
+    if(!m_audioRouted && m_btSourceReady && m_btSinkReady)
+    {
+        DEBUG_T("Route microphone and speakers");
+        //routeAudio();
+    }
+}
+
+/*
+void PAControl::onCallsChanged()
+{
+    TRACE;
+    if(!m_isInitialized) this->paInit();
+
+    if (m_manager->voiceCallCount() > 1)
+    {
+        // new call is dialing or phone is picked up
+        DEBUG_T("PAControl: new call in progress");
+
+        if(m_audioRouted)
+        {
+            DEBUG_T("Audio already routed");
+            return;
+        }
+
+        if(m_btSourceReady && m_btSinkReady)
+        {
+            DEBUG_T("Route microphone and speakers");
+            routeAudio();
+        }
+        else
+        {
+            if(this->findBluezSource() != NULL && this->findBluezSink() != NULL)
+            {
+                // bt source and sink exists
+                m_btSourceReady = true;
+                m_btSinkReady = true;
+                DEBUG_T("Route microphone and speakers");
+                routeAudio();
+            }
+            else
+            {
+                //no bt source or sink yet, let's wait until source and sink appears
+                m_btSourceReady = false;
+                m_btSinkReady = false;
+                connect(this, SIGNAL(sourceAppeared(PADevice*)), this, SLOT(onSourceAppeared(PADevice*)));
+                connect(this, SIGNAL(sinkAppeared(PADevice*)), this, SLOT(onSinkAppeared(PADevice*)));
+                DEBUG_T("Audio not routed yet, wait for bt source and sinks");
+            }
+        }
+    }
+    else if (m_manager->voiceCallCount() <= 0)
+    {
+        DEBUG_T("no more ofono calls");
+        if(m_audioRouted)
+        {
+            DEBUG_T("Unroute microphone and speakers");
+            unrouteAudio();
+        }
+    }
+}
+*/

--- a/plugins/pulseaudio/src/pacontrol.h
+++ b/plugins/pulseaudio/src/pacontrol.h
@@ -1,0 +1,137 @@
+/*
+ * hfdialer - Hands Free Voice Call Manager
+ * Copyright (c) 2012, Intel Corporation.
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+#ifndef PACONTROL_H
+#define PACONTROL_H
+#include <pulse/context.h>
+#include <pulse/pulseaudio.h>
+#include <pulse/glib-mainloop.h>
+#include <QObject>
+
+#include <voicecallmanagerinterface.h>
+
+struct PADevice
+{
+    int     index;
+    QString name;
+    QString description;
+};
+
+struct PAModule
+{
+    int     index;
+    QString name;
+    QString arguments;
+};
+
+enum PAStatus {
+    SUCCESS = 0,
+    ERROR
+};
+
+class PAControl : public QObject
+{
+    Q_OBJECT
+
+public:
+    ~PAControl();
+
+    static PAControl* instance(VoiceCallManagerInterface *manager);
+    void reconnect();
+
+    PADevice* findBluezSource();
+    PADevice* findBluezSink();
+    PADevice* findAlsaSource(QString alsasource);
+    PADevice* findAlsaSink(QString alsasink);
+    PAModule* findModule(QString name, QString pattern);
+
+    QList<PAModule*> getAllModules();
+
+    void setSourcePortByName(PADevice *source, const QString &port);
+    void setSinkPortByName(PADevice *sink, const QString &port);
+
+    void routeSourceWithSink(PADevice *source, PADevice *sink);
+
+    void unloadModule(PAModule* module);
+
+    void toggleMuteSink(PADevice *sink, bool isMute);
+    void toggleMuteSource(PADevice *source, bool isMute);
+
+    PAStatus getStatus();
+    void setErrorMsg(QString msg);
+    QString getErrorMsg();
+
+    void setState(bool state);
+    void addRef();
+    void release();
+
+    void addSource(PADevice* device);
+    void addSink(PADevice* device);
+    void addModule(PAModule* module);
+
+    QList<PADevice*> sourceList;
+    QList<PADevice*> sinkList;
+    QList<PAModule*> moduleList;
+
+    // Audio routing policy information.
+    PADevice *source;
+    PADevice *sink;
+
+    PADevice *input;
+    QString   input_port;
+    PADevice *input_source;
+
+    PADevice *output;
+    QString   output_port;
+    PADevice *output_sink;
+
+public Q_SLOTS:
+    void routeAudio();
+    void unrouteAudio();
+
+Q_SIGNALS:
+    void sourceAppeared(PADevice* device);
+    void sinkAppeared(PADevice* device);
+    void moduleAppeared(PAModule* device);
+    void paFailed();
+
+private Q_SLOTS:
+    void onSourceAppeared(PADevice* device);
+    void onSinkAppeared(PADevice* device);
+
+private:
+    PAControl(VoiceCallManagerInterface *manager, QObject *parent = 0);
+
+    pa_operation *pa_op;
+    pa_context *pa_ctx;
+    PAStatus status;
+    QString errorMsg;
+
+    void paInit();
+    void paCleanup();
+
+    VoiceCallManagerInterface *m_manager;
+
+    bool m_isInitialized;
+    bool m_paState;
+    int  m_refCounter;
+    bool m_connected;
+    bool m_audioRouted;
+    bool m_btSourceReady;
+    bool m_btSinkReady;
+};
+
+#endif // PACONTROL_H
+
+/* Local Variables:      */
+/* mode:c++              */
+/* c-basic-offset:4      */
+/* indent-tabs-mode: nil */
+/* End:                  */

--- a/plugins/pulseaudio/src/pulseaudioroutingplugin.cpp
+++ b/plugins/pulseaudio/src/pulseaudioroutingplugin.cpp
@@ -1,0 +1,448 @@
+/*
+ * This file is a part of the Voice Call Manager Pulse Audio Plugin project.
+ * Copyright (c) 2012-2012 Tom Swindell <t.swindell@rubyx.co.uk>
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+#include "common.h"
+#include "pulseaudioroutingplugin.h"
+
+#include "pacontrol.h"
+
+#include <QSettings>
+#include <QStringList>
+#include <QtPlugin>
+
+#define MODE_POLICY_FILEPATH  "/etc/voicecall/modes.ini"
+
+#define MODE_KEY_SOURCE       "source"
+#define MODE_KEY_SINK         "sink"
+#define MODE_KEY_INPUT        "input"
+#define MODE_KEY_INPUT_PORT   "input-port"
+#define MODE_KEY_INPUT_SOURCE "input-source"
+#define MODE_KEY_OUTPUT       "output"
+#define MODE_KEY_OUTPUT_PORT  "output-port"
+#define MODE_KEY_OUTPUT_SINK  "output-sink"
+
+#define MODE_GLOBAL_NAME      ".global"
+#define MODE_DEFAULT_NAME     ".default"
+
+class PulseAudioRoutingPluginPrivate
+{
+    Q_DECLARE_PUBLIC(PulseAudioRoutingPlugin)
+
+public:
+    PulseAudioRoutingPluginPrivate(PulseAudioRoutingPlugin *q)
+        : q_ptr(q), manager(NULL), control(NULL),
+          isInitialized(false),
+          isConfigured(false),
+          isRouted(false),
+          isMicrophoneMuted(false),
+          isSpeakerMuted(false)
+    {/*...*/}
+
+    PulseAudioRoutingPlugin     *q_ptr;
+    VoiceCallManagerInterface   *manager;
+
+    PAControl                   *control;
+
+    bool                         isInitialized;
+    bool                         isConfigured;
+
+    bool                         isRouted;
+    bool                         isMicrophoneMuted;
+    bool                         isSpeakerMuted;
+
+    AudioRoutingMode                  mode;
+    QHash<QString,AudioRoutingMode>   modes;
+};
+
+PulseAudioRoutingPlugin::PulseAudioRoutingPlugin(QObject *parent)
+    : AbstractVoiceCallManagerPlugin(parent), d_ptr(new PulseAudioRoutingPluginPrivate(this))
+{
+    TRACE
+}
+
+PulseAudioRoutingPlugin::~PulseAudioRoutingPlugin()
+{
+    TRACE
+    Q_D(PulseAudioRoutingPlugin);
+    delete d;
+}
+
+QString PulseAudioRoutingPlugin::pluginId() const
+{
+    TRACE
+    return PLUGIN_NAME;
+}
+
+QString PulseAudioRoutingPlugin::mode() const
+{
+    TRACE
+    Q_D(const PulseAudioRoutingPlugin);
+    return d->mode.name;
+}
+
+bool PulseAudioRoutingPlugin::isModeValid(const AudioRoutingMode &mode)
+{
+    TRACE
+    bool ok = true;
+
+    if(mode.source.isNull() && mode.source.isEmpty())
+    {
+        WARNING_T("Mode has no source defined!");
+        ok &= false;
+    }
+    if(mode.sink.isNull() && mode.sink.isEmpty())
+    {
+        WARNING_T("Mode has no sink defined!");
+        ok &= false;
+    }
+    if(mode.input.isNull() && mode.input.isEmpty())
+    {
+        WARNING_T("Mode has no input defined!");
+        ok &= false;
+    }
+    if(mode.input_port.isNull() && mode.input_port.isEmpty())
+    {
+        WARNING_T("Mode has no input port defined!");
+        ok &= false;
+    }
+    if(mode.input_source.isNull() && mode.input_source.isEmpty())
+    {
+        WARNING_T("Mode has no input source defined!");
+        ok &= false;
+    }
+    if(mode.output.isNull() && mode.output.isEmpty())
+    {
+        WARNING_T("Mode has no source defined!");
+        ok &= false;
+    }
+    if(mode.output_port.isNull() && mode.output_port.isEmpty())
+    {
+        WARNING_T("Mode has no output port defined!");
+        ok &= false;
+    }
+    if(mode.output_sink.isNull() && mode.output_sink.isEmpty())
+    {
+        WARNING_T("Mode has no output sink defined!");
+        ok &= false;
+    }
+
+    return ok;
+}
+
+bool PulseAudioRoutingPlugin::initialize()
+{
+    TRACE
+    Q_D(PulseAudioRoutingPlugin);
+    QSettings settings(MODE_POLICY_FILEPATH, QSettings::IniFormat, this);
+
+    foreach(QString group, settings.childGroups())
+    {
+        AudioRoutingMode mode;
+        settings.beginGroup(group);
+
+        mode.name         = group;
+        mode.source       = settings.value(MODE_KEY_SOURCE).toString();
+        mode.sink         = settings.value(MODE_KEY_SINK).toString();
+        mode.input        = settings.value(MODE_KEY_INPUT).toString();
+        mode.input_port   = settings.value(MODE_KEY_INPUT_PORT).toString();
+        mode.input_source = settings.value(MODE_KEY_INPUT_SOURCE).toString();
+        mode.output       = settings.value(MODE_KEY_OUTPUT).toString();
+        mode.output_port  = settings.value(MODE_KEY_OUTPUT_PORT).toString();
+        mode.output_sink  = settings.value(MODE_KEY_OUTPUT_SINK).toString();
+
+        DEBUG_T(QString("Read policy mode configuration: ") + mode.name);
+        d->modes.insert(mode.name, mode);
+
+        settings.endGroup();
+    }
+
+    // Check for at least a complete ".default" configuration.
+    if(!d->modes.contains(MODE_DEFAULT_NAME))
+    {
+        WARNING_T("No default audio routing mode defined!");
+        return false;
+    }
+
+    d->isInitialized = true;
+    return true;
+}
+
+bool PulseAudioRoutingPlugin::configure(VoiceCallManagerInterface *manager)
+{
+    TRACE
+    Q_D(PulseAudioRoutingPlugin);
+    if(!d->isInitialized)
+    {
+        WARNING_T("Not initialized!")
+        return false;
+    }
+
+    d->manager = manager;
+    d->control = PAControl::instance(d->manager);
+
+    QObject::connect(d->manager, SIGNAL(setAudioModeRequested(QString)), SLOT(setMode(QString)));
+    QObject::connect(d->manager, SIGNAL(setAudioRoutedRequested(bool)), SLOT(setRouted(bool)));
+    QObject::connect(d->manager, SIGNAL(setMuteMicrophoneRequested(bool)), SLOT(setMuteMicrophone(bool)));
+    QObject::connect(d->manager, SIGNAL(setMuteSpeakerRequested(bool)), SLOT(setMuteSpeaker(bool)));
+
+    this->setMode(MODE_DEFAULT_NAME);
+
+    d->isConfigured = true;
+    return true;
+}
+
+bool PulseAudioRoutingPlugin::start()
+{
+    TRACE
+    return true;
+}
+
+bool PulseAudioRoutingPlugin::suspend()
+{
+    TRACE
+    return true;
+}
+
+bool PulseAudioRoutingPlugin::resume()
+{
+    TRACE
+    return true;
+}
+
+void PulseAudioRoutingPlugin::finalize()
+{
+    TRACE
+}
+
+bool PulseAudioRoutingPlugin::setMode(const QString &mode)
+{
+    TRACE
+    Q_D(PulseAudioRoutingPlugin);
+    if(!d->isInitialized)
+    {
+        WARNING_T("Not initialized!")
+        return false;
+    }
+
+    AudioRoutingMode target;
+    bool ok = true;
+
+    if(!d->modes.contains(mode))
+    {
+        WARNING_T(QString("Failed to find audio routing mode: ") + mode);
+        WARNING_T("Switching to default...");
+        target = d->modes.value(MODE_DEFAULT_NAME);
+        ok = false;
+    }
+    else
+    {
+        target = d->modes.value(mode);
+    }
+
+    if(target.name == d->mode.name)
+    {
+        DEBUG_T(QString("Audio routing mode already set to: ") + target.name);
+        return true;
+    }
+
+    // Fill in global defaults for values missing from policy.
+    if(d->modes.contains(MODE_GLOBAL_NAME))
+    {
+        AudioRoutingMode global = d->modes.value(MODE_GLOBAL_NAME);
+
+        if(target.source.isNull() || target.source.isEmpty())
+            target.source = global.source;
+
+        if(target.sink.isNull() || target.sink.isEmpty())
+            target.sink = global.sink;
+
+        if(target.input.isNull() || target.input.isEmpty())
+            target.input = global.input;
+
+        if(target.input_port.isNull() || target.input_port.isEmpty())
+            target.input_port = global.input_port;
+
+        if(target.input_source.isNull() || target.input_source.isEmpty())
+            target.input_source = global.input_source;
+
+        if(target.output.isNull() || target.output.isEmpty())
+            target.output = global.output;
+
+        if(target.output_port.isNull() || target.output_port.isEmpty())
+            target.output_port = global.output_port;
+
+        if(target.output_sink.isNull() || target.output_sink.isEmpty())
+            target.output_sink = global.output_sink;
+    }
+
+    ok &= this->isModeValid(target);
+
+    if(ok)
+    {
+        DEBUG_T(QString("Successfully configured mode: ") + target.name);
+        d->mode = target;
+        emit this->modeChanged();
+
+        if(d->isRouted)
+        {
+            d->isRouted = false; // To force re-routing of the audio.
+            this->routeAudio();
+        }
+    }
+    else
+    {
+        DEBUG_T(QString("Failed to configure mode: ") + target.name);
+    }
+
+    return ok;
+}
+
+bool PulseAudioRoutingPlugin::setMuteMicrophone(bool on)
+{
+    TRACE
+    Q_D(PulseAudioRoutingPlugin);
+    if(!d->isInitialized)
+    {
+        WARNING_T("Not initialized!")
+        return false;
+    }
+
+    if(!d->isRouted)
+    {
+        DEBUG_T("Audio not routed, returning.")
+        return true;
+    }
+
+    d->control->toggleMuteSource(d->control->input_source, on);
+    return true;
+}
+
+bool PulseAudioRoutingPlugin::setMuteSpeaker(bool on)
+{
+    TRACE
+    Q_D(PulseAudioRoutingPlugin);
+    if(!d->isInitialized)
+    {
+        WARNING_T("Not initialized!")
+        return false;
+    }
+
+    if(!d->isRouted)
+    {
+        DEBUG_T("Audio not routed, returning.")
+        return true;
+    }
+
+    d->control->toggleMuteSink(d->control->output_sink, on);
+    return true;
+}
+
+bool PulseAudioRoutingPlugin::setRouted(bool on)
+{
+    TRACE
+    return on ? routeAudio() : unrouteAudio();
+}
+
+bool PulseAudioRoutingPlugin::routeAudio()
+{
+    TRACE
+    Q_D(PulseAudioRoutingPlugin);
+    if(!d->isInitialized)
+    {
+        WARNING_T("Not initialized!")
+        return false;
+    }
+
+    if(!this->isModeValid(d->mode))
+    {
+        WARNING_T("No valid mode configured!");
+        return false;
+    }
+
+    if(d->isRouted)
+    {
+        DEBUG_T("Audio already routed.")
+        return true;
+    }
+
+    int ok = true;
+
+    if(!(d->control->source = d->control->findAlsaSource(d->mode.source)))
+    {
+        WARNING_T(QString("Failed to find source: ") + d->mode.source);
+        ok &= false;
+    }
+
+    if(!(d->control->sink = d->control->findAlsaSink(d->mode.sink)))
+    {
+        WARNING_T(QString("Failed to find sink: ") + d->mode.sink);
+        ok &= false;
+    }
+    if(!(d->control->input = d->control->findAlsaSource(d->mode.input)))
+    {
+        WARNING_T(QString("Failed to find input: ") + d->mode.input);
+        ok &= false;
+    }
+    if(!(d->control->input_source = d->control->findAlsaSource(d->mode.input_source)))
+    {
+        WARNING_T(QString("Failed to find input source: ") + d->mode.input_source);
+        ok &= false;
+    }
+    if(!(d->control->output = d->control->findAlsaSink(d->mode.output)))
+    {
+        WARNING_T(QString("Failed to find output: ") + d->mode.output);
+        ok &= false;
+    }
+    if(!(d->control->output_sink = d->control->findAlsaSink(d->mode.output_sink)))
+    {
+        WARNING_T(QString("Failed to find output sink: ") + d->mode.output_sink);
+        ok &= false;
+    }
+
+    d->control->input_port = d->mode.input_port;
+    d->control->output_port = d->mode.output_port;
+
+    if(ok)
+    {
+        DEBUG_T("Found all stream components, routing audio.");
+        d->control->routeAudio();
+    }
+    else
+    {
+        DEBUG_T("Failed to find all stream components, failing.");
+        if(d->isRouted) d->control->unrouteAudio();
+        ok = false;
+    }
+
+    d->isRouted = ok;
+    return ok;
+}
+
+bool PulseAudioRoutingPlugin::unrouteAudio()
+{
+    TRACE
+    Q_D(PulseAudioRoutingPlugin);
+    if(!d->isInitialized)
+    {
+        WARNING_T("Not initialized!")
+        return false;
+    }
+
+    if(!d->isRouted)
+    {
+        DEBUG_T("Audio already not routed.")
+        return true;
+    }
+
+    d->control->unrouteAudio();
+    d->isRouted = false;
+
+    return true;
+}
+

--- a/plugins/pulseaudio/src/pulseaudioroutingplugin.h
+++ b/plugins/pulseaudio/src/pulseaudioroutingplugin.h
@@ -1,0 +1,74 @@
+/*
+ * This file is a part of the Voice Call Manager Pulse Audio Plugin project.
+ * Copyright (c) 2012-2012 Tom Swindell <t.swindell@rubyx.co.uk>
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+#ifndef PULSEAUDIOROUTINGPLUGIN_H
+#define PULSEAUDIOROUTINGPLUGIN_H
+
+#include <abstractvoicecallmanagerplugin.h>
+
+struct AudioRoutingMode
+{
+    QString name;
+    QString source; // source.voice - source and destination call audio.
+    QString sink;   // sink.voice - source and destination call audio.
+    QString input;
+    QString input_port;
+    QString input_source;
+    QString output;
+    QString output_port;
+    QString output_sink;
+};
+
+class PulseAudioRoutingPlugin : public AbstractVoiceCallManagerPlugin
+{
+    Q_OBJECT
+
+    Q_PLUGIN_METADATA(IID "org.nemomobile.voicecall.pulseaudio")
+    Q_INTERFACES(AbstractVoiceCallManagerPlugin)
+
+    Q_PROPERTY(QString mode READ mode WRITE setMode NOTIFY modeChanged)
+
+public:
+    explicit PulseAudioRoutingPlugin(QObject *parent = 0);
+            ~PulseAudioRoutingPlugin();
+    
+    QString pluginId() const;
+
+    QString mode() const;
+
+Q_SIGNALS:
+    void modeChanged();
+
+public Q_SLOTS:
+    bool initialize();
+    bool configure(VoiceCallManagerInterface *manager);
+    bool start();
+    bool suspend();
+    bool resume();
+    void finalize();
+
+public Q_SLOTS:
+    bool setMode(const QString &mode);
+    bool setRouted(bool on = true);
+    bool setMuteMicrophone(bool on = true);
+    bool setMuteSpeaker(bool on = true);
+
+protected:
+    static bool isModeValid(const AudioRoutingMode &mode);
+
+    bool routeAudio();
+    bool unrouteAudio();
+
+private:
+    class PulseAudioRoutingPluginPrivate *d_ptr;
+
+    Q_DECLARE_PRIVATE(PulseAudioRoutingPlugin)
+};
+
+#endif // PULSEAUDIOROUTINGPLUGIN_H

--- a/plugins/pulseaudio/src/src.pro
+++ b/plugins/pulseaudio/src/src.pro
@@ -1,0 +1,16 @@
+include(../../plugin.pri)
+TARGET = voicecall-pulseaudio-plugin
+
+DEFINES += PLUGIN_NAME=\\\"voicecall-pulseaudio-plugin\\\"
+
+#DEFINES += WANT_TRACE
+
+PKGCONFIG += libpulse-mainloop-glib
+
+HEADERS += \
+    pacontrol.h \
+    pulseaudioroutingplugin.h
+
+SOURCES += \
+    pacontrol.cpp \
+    pulseaudioroutingplugin.cpp

--- a/plugins/resource-policy-routing/resource-policy-routing.pro
+++ b/plugins/resource-policy-routing/resource-policy-routing.pro
@@ -1,0 +1,4 @@
+TEMPLATE = subdirs
+SUBDIRS = src
+
+OTHER_FILES += LICENSE

--- a/plugins/resource-policy-routing/src/resourcepolicyroutingplugin.cpp
+++ b/plugins/resource-policy-routing/src/resourcepolicyroutingplugin.cpp
@@ -1,0 +1,320 @@
+/*
+ * This file is a part of the Voice Call Manager project
+ *
+ * Copyright (C) 2011-2012  Tom Swindell <t.swindell@rubyx.co.uk>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#include "common.h"
+#include "resourcepolicyroutingplugin.h"
+
+#include "voicecallmanagerinterface.h"
+
+#include <QtDBus>
+#include <QVariant>
+#include <QtPlugin>
+
+
+struct AudioActionProp
+{
+    QString key;
+    QDBusVariant value;
+
+    AudioActionProp() {}
+    AudioActionProp(const QString &k, const QDBusVariant &v)
+        : key(k), value(v) { /* ... */ }
+
+    bool isValid() const {return !key.isNull() && !key.isEmpty();}
+};
+
+typedef QList<AudioActionProp> AudioActionPropList;
+
+Q_DECLARE_METATYPE(AudioActionProp)
+Q_DECLARE_METATYPE(AudioActionPropList)
+
+QDBusArgument &operator<<(QDBusArgument &arg, const AudioActionProp &prop)
+{
+    qDebug() << "action prop operator <<";
+
+    arg.beginStructure();
+    arg << prop.key << prop.value;
+    arg.endStructure();
+
+    return arg;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &arg, AudioActionProp &prop)
+{
+    qDebug() << "action prop operator >>";
+    return arg;
+}
+
+struct AudioActionObject
+{
+    AudioActionPropList props;
+
+    bool isValid() const {return !props.isEmpty();}
+};
+
+typedef QList<AudioActionObject> AudioActionObjectList;
+
+Q_DECLARE_METATYPE(AudioActionObject)
+Q_DECLARE_METATYPE(AudioActionObjectList)
+
+QDBusArgument &operator<<(QDBusArgument &arg, const AudioActionObject &obj)
+{
+    qDebug() << "action object operator <<";
+    arg << obj.props;
+    return arg;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &arg, AudioActionObject &obj)
+{
+    qDebug() << "action object operator >>";
+    return arg;
+}
+
+struct AudioAction
+{
+    QString action;
+    AudioActionObjectList objects;
+
+    bool isValid() const {return !action.isNull() && !action.isEmpty();}
+};
+
+typedef QList<AudioAction> AudioActionList;
+
+Q_DECLARE_METATYPE(AudioAction)
+Q_DECLARE_METATYPE(AudioActionList)
+
+QDBusArgument &operator<<(QDBusArgument &argument, const AudioAction &a)
+{
+    qDebug() << "action operator <<";
+
+    argument.beginMap(QVariant::String, qMetaTypeId<AudioActionObjectList>());
+    if(a.isValid())
+    {
+        argument.beginMapEntry();
+        argument << a.action;
+        argument << a.objects;
+        argument.endMapEntry();
+    }
+    argument.endMap();
+
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, AudioAction &a)
+{
+    qDebug() << "action operator >>";
+    return argument;
+}
+
+class ResourcePolicyRoutingPluginPrivate
+{
+    Q_DECLARE_PUBLIC(ResourcePolicyRoutingPlugin)
+
+public:
+    ResourcePolicyRoutingPluginPrivate(ResourcePolicyRoutingPlugin *q)
+        : q_ptr(q), manager(NULL)
+    { /* ... */ }
+
+    ResourcePolicyRoutingPlugin *q_ptr;
+    VoiceCallManagerInterface   *manager;
+
+    QDBusInterface *iface;
+};
+
+ResourcePolicyRoutingPlugin::ResourcePolicyRoutingPlugin(QObject *parent) :
+    AbstractVoiceCallManagerPlugin(parent), d_ptr(new ResourcePolicyRoutingPluginPrivate(this))
+{
+    TRACE
+}
+
+ResourcePolicyRoutingPlugin::~ResourcePolicyRoutingPlugin()
+{
+    TRACE
+    delete this->d_ptr;
+}
+
+QString ResourcePolicyRoutingPlugin::pluginId() const
+{
+    TRACE
+    return PLUGIN_NAME;
+}
+
+bool ResourcePolicyRoutingPlugin::initialize()
+{
+    TRACE
+    qDBusRegisterMetaType<AudioActionProp>();
+    qDBusRegisterMetaType<AudioActionPropList>();
+    qDBusRegisterMetaType<AudioActionObject>();
+    qDBusRegisterMetaType<AudioActionObjectList>();
+    qDBusRegisterMetaType<AudioAction>();
+    qDBusRegisterMetaType<AudioActionList>();
+    return true;
+}
+
+bool ResourcePolicyRoutingPlugin::configure(VoiceCallManagerInterface *manager)
+{
+    TRACE
+    Q_D(ResourcePolicyRoutingPlugin);
+    d->manager = manager;
+
+    QObject::connect(d->manager, SIGNAL(voiceCallsChanged()), SLOT(onVoiceCallsChanged()));
+
+    QObject::connect(d->manager, SIGNAL(setAudioModeRequested(QString)), SLOT(setMode(QString)));
+    QObject::connect(d->manager, SIGNAL(setMuteMicrophoneRequested(bool)), SLOT(setMuteMicrophone(bool)));
+    QObject::connect(d->manager, SIGNAL(setMuteSpeakerRequested(bool)), SLOT(setMuteSpeaker(bool)));
+
+    return true;
+}
+
+bool ResourcePolicyRoutingPlugin::start()
+{
+    TRACE
+    return true;
+}
+
+bool ResourcePolicyRoutingPlugin::suspend()
+{
+    TRACE
+    return true;
+}
+
+bool ResourcePolicyRoutingPlugin::resume()
+{
+    TRACE
+    return true;
+}
+
+void ResourcePolicyRoutingPlugin::finalize()
+{
+    TRACE
+}
+
+void ResourcePolicyRoutingPlugin::setMode(const QString &mode)
+{
+    TRACE
+    Q_D(ResourcePolicyRoutingPlugin);
+
+    AudioAction act;
+    AudioActionObject obj;
+    AudioActionProp sink_device("device", QDBusVariant("earpiece"));
+    AudioActionProp sink_mode("mode", QDBusVariant("na"));
+
+    if(mode == "ihf")
+    {
+        sink_device.value = QDBusVariant("ihf");
+        sink_mode.value = QDBusVariant("ihf");
+    }
+
+    act.action = "com.nokia.policy.audio_route";
+    obj.props << AudioActionProp("type", QDBusVariant("sink"));
+    obj.props << sink_device;
+    obj.props << sink_mode;
+    obj.props << AudioActionProp("hwid", QDBusVariant("na"));
+    act.objects << obj;
+
+    QDBusMessage message = QDBusMessage::createSignal("/com/nokia/policy/decision",
+                                                      "com.nokia.policy",
+                                                      "audio_actions");
+    message << (uint)0;
+    message << qVariantFromValue(act);
+
+    if(!QDBusConnection::systemBus().send(message))
+    {
+        WARNING_T("Failed to send policy audio_actions signal.");
+        return;
+    }
+
+    d->manager->onAudioModeChanged(mode);
+}
+
+void ResourcePolicyRoutingPlugin::setMuteMicrophone(bool on)
+{
+    TRACE
+    Q_D(ResourcePolicyRoutingPlugin);
+
+    AudioAction act;
+    AudioActionObject a;
+
+    act.action = "com.nokia.policy.audio_mute";
+
+    a.props << AudioActionProp("device", QDBusVariant("microphone"));
+    a.props << AudioActionProp("mute", on ? QDBusVariant("muted") : QDBusVariant("unmuted"));
+
+    act.objects << a;
+
+    QDBusMessage message = QDBusMessage::createSignal("/com/nokia/policy/decision",
+                                                      "com.nokia.policy",
+                                                      "audio_actions");
+    message << (uint)0;
+    message << qVariantFromValue(act);
+
+    if(!QDBusConnection::systemBus().send(message))
+    {
+        WARNING_T("Failed to send policy audio_actions signal.");
+        return;
+    }
+
+    d->manager->onMuteMicrophoneChanged(on);
+}
+
+void ResourcePolicyRoutingPlugin::setMuteSpeaker(bool on)
+{
+    TRACE
+    Q_D(ResourcePolicyRoutingPlugin);
+
+    AudioAction act;
+    AudioActionObject a;
+
+    act.action = "com.nokia.policy.audio_mute";
+
+    a.props << AudioActionProp("device", QDBusVariant("headset"));
+    a.props << AudioActionProp("mute", on ? QDBusVariant("muted") : QDBusVariant("unmuted"));
+
+    act.objects << a;
+
+    QDBusMessage message = QDBusMessage::createSignal("/com/nokia/policy/decision",
+                                                      "com.nokia.policy",
+                                                      "audio_actions");
+    message << (uint)0;
+    message << qVariantFromValue(act);
+
+    if(!QDBusConnection::systemBus().send(message))
+    {
+        WARNING_T("Failed to send policy audio_actions signal.");
+        return;
+    }
+
+    d->manager->onMuteSpeakerChanged(on);
+}
+
+void ResourcePolicyRoutingPlugin::onVoiceCallsChanged()
+{
+    TRACE
+    Q_D(ResourcePolicyRoutingPlugin);
+
+    // When all calls are done, we reset audio policy to a sensible state.
+    if(d->manager->voiceCalls().empty())
+    {
+        this->setMode("earpiece");
+        this->setMuteMicrophone(false);
+        this->setMuteSpeaker(false);
+    }
+}
+

--- a/plugins/resource-policy-routing/src/resourcepolicyroutingplugin.h
+++ b/plugins/resource-policy-routing/src/resourcepolicyroutingplugin.h
@@ -1,0 +1,61 @@
+/*
+ * This file is a part of the Voice Call Manager project
+ *
+ * Copyright (C) 2011-2012  Tom Swindell <t.swindell@rubyx.co.uk>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#ifndef RESOURCEPOLICYROUTINGPLUGIN_H
+#define RESOURCEPOLICYROUTINGPLUGIN_H
+
+#include <abstractvoicecallmanagerplugin.h>
+
+class ResourcePolicyRoutingPlugin : public AbstractVoiceCallManagerPlugin
+{
+    Q_OBJECT
+
+    Q_PLUGIN_METADATA(IID "org.nemomobile.voicecall.resourcepolicy")
+    Q_INTERFACES(AbstractVoiceCallManagerPlugin)
+
+public:
+    explicit ResourcePolicyRoutingPlugin(QObject *parent = 0);
+            ~ResourcePolicyRoutingPlugin();
+
+    QString pluginId() const;
+
+public Q_SLOTS:
+    bool initialize();
+    bool configure(VoiceCallManagerInterface *manager);
+    bool start();
+    bool suspend();
+    bool resume();
+    void finalize();
+
+public Q_SLOTS:
+    void setMode(const QString &mode);
+    void setMuteMicrophone(bool on = true);
+    void setMuteSpeaker(bool on = true);
+
+protected Q_SLOTS:
+    void onVoiceCallsChanged();
+
+private:
+    class ResourcePolicyRoutingPluginPrivate *d_ptr;
+
+    Q_DECLARE_PRIVATE(ResourcePolicyRoutingPlugin)
+};
+
+#endif // RESOURCEPOLICYROUTINGPLUGIN_H

--- a/plugins/resource-policy-routing/src/src.pro
+++ b/plugins/resource-policy-routing/src/src.pro
@@ -1,0 +1,14 @@
+include(../../plugin.pri)
+TARGET = voicecall-resource-policy-routing-plugin
+QT += dbus
+
+DEFINES += PLUGIN_NAME=\\\"resource-policy-routing-plugin\\\"
+
+#DEFINES += WANT_TRACE
+
+HEADERS += \
+    resourcepolicyroutingplugin.h
+
+SOURCES += \
+    resourcepolicyroutingplugin.cpp
+

--- a/rpm/voicecall-qt5.spec
+++ b/rpm/voicecall-qt5.spec
@@ -31,16 +31,8 @@ BuildRequires:  pkgconfig(TelepathyQt5Farstream)
 BuildRequires:  pkgconfig(ngf-qt5)
 Provides:   voicecall-core >= 0.4.9
 Provides:   voicecall-libs >= 0.4.9
-Provides:   voicecall-plugin-pulseaudio >= 0.4.9
-Provides:   voicecall-qt5-plugin-pulseaudio >= 0.5.1
-Provides:   voicecall-plugin-resource-policy >= 0.4.9
-Provides:   voicecall-qt5-plugin-resource-policy >= 0.5.1
 Obsoletes:   voicecall-core < 0.4.9
 Obsoletes:   voicecall-libs < 0.4.9
-Obsoletes:   voicecall-plugin-pulseaudio < 0.4.9
-Obsoletes:   voicecall-qt5-plugin-pulseaudio < 0.5.1
-Obsoletes:   voicecall-plugin-resource-policy < 0.4.9
-Obsoletes:   voicecall-qt5-plugin-resource-policy < 0.5.1
 
 %description
 %{summary}.
@@ -63,6 +55,26 @@ Provides:   voicecall-plugin-ofono >= 0.4.9
 Obsoletes:  voicecall-plugin-ofono < 0.4.9
 
 %description plugin-ofono
+%{summary}.
+
+%package plugin-pulseaudio
+Summary:    Voicecall plugin for direct pulseaudio audio routing and stream control.
+Group:      Communications/Telephony
+Requires:   %{name} = %{version}-%{release}
+Provides:   voicecall-plugin-pulseaudio >= 0.4.9
+Obsoletes:  voicecall-plugin-pulseaudio < 0.4.9
+
+%description plugin-pulseaudio
+%{summary}.
+
+%package plugin-resource-policy
+Summary:    Voicecall plugin for resource policy audio routing and stream control.
+Group:      Communications/Telephony
+Requires:   %{name} = %{version}-%{release}
+Provides:   voicecall-plugin-resource-policy >= 0.4.9
+Obsoletes:  voicecall-plugin-resource-policy < 0.4.9
+
+%description plugin-resource-policy
 %{summary}.
 
 %prep
@@ -139,3 +151,16 @@ fi
 %{_libdir}/voicecall/plugins/libvoicecall-ofono-plugin.so
 # >> files plugin-ofono
 # << files plugin-ofono
+
+%files plugin-pulseaudio
+%defattr(-,root,root,-)
+%{_libdir}/voicecall/plugins/libvoicecall-pulseaudio-plugin.so
+%config %{_sysconfdir}/voicecall/modes.ini
+# >> files plugin-pulseaudio
+# << files plugin-pulseaudio
+
+%files plugin-resource-policy
+%defattr(-,root,root,-)
+%{_libdir}/voicecall/plugins/libvoicecall-resource-policy-routing-plugin.so
+# >> files plugin-resource-policy
+# << files plugin-resource-policy

--- a/rpm/voicecall-qt5.yaml
+++ b/rpm/voicecall-qt5.yaml
@@ -38,18 +38,9 @@ Files:
 Provides:
     - voicecall-core >= 0.4.9
     - voicecall-libs >= 0.4.9
-    - voicecall-plugin-pulseaudio >= 0.4.9
-    - voicecall-qt5-plugin-pulseaudio >= 0.5.1 # replaced by ohm functionality
-    - voicecall-plugin-resource-policy >= 0.4.9
-    - voicecall-qt5-plugin-resource-policy >= 0.5.1 # replaced by ohm functionality
 Obsoletes:
     - voicecall-core < 0.4.9
     - voicecall-libs < 0.4.9
-    - voicecall-plugin-pulseaudio < 0.4.9
-    - voicecall-qt5-plugin-pulseaudio < 0.5.1 # replaced by ohm functionality
-    - voicecall-plugin-resource-policy < 0.4.9
-    - voicecall-qt5-plugin-resource-policy < 0.5.1 # replaced by ohm functionality
-
 SubPackages:
     - Name: devel
       Summary: Voicecall development package
@@ -72,4 +63,27 @@ SubPackages:
           - voicecall-plugin-ofono < 0.4.9
       Files:
           - "%{_libdir}/voicecall/plugins/libvoicecall-ofono-plugin.so"
+
+    - Name: plugin-pulseaudio
+      Summary: Voicecall plugin for direct pulseaudio audio routing and stream control.
+      Description: "%{summary}."
+      Group: Communications/Telephony
+      Provides:
+          - voicecall-plugin-pulseaudio >= 0.4.9
+      Obsoletes:
+          - voicecall-plugin-pulseaudio < 0.4.9
+      Files:
+          - "%{_libdir}/voicecall/plugins/libvoicecall-pulseaudio-plugin.so"
+          - "%config %{_sysconfdir}/voicecall/modes.ini"
+
+    - Name: plugin-resource-policy
+      Summary: Voicecall plugin for resource policy audio routing and stream control.
+      Description: "%{summary}."
+      Group: Communications/Telephony
+      Provides:
+          - voicecall-plugin-resource-policy >= 0.4.9
+      Obsoletes:
+          - voicecall-plugin-resource-policy < 0.4.9
+      Files:
+          - "%{_libdir}/voicecall/plugins/libvoicecall-resource-policy-routing-plugin.so"
 


### PR DESCRIPTION
This reverts commit e88d2d822019013fbe4b97064a8ab4c3f0091b30.

With these plugins available, I'm able to use the ofono manager to make calls, with audio, without using Telepathy.

To do so, install the ofono, pulseaudio, and resource-policy-routing plugins; remove the voicecall telepathy plugin; disable telepathy-ring with:

mc-tool disable ring/tel/account0

Restart relevant processes and calls should be functional.
