### PR TITLE
[voicecall] Fix incoming ring tone.

### DIFF
--- a/plugins/ngf/src/ngfringtoneplugin.cpp
+++ b/plugins/ngf/src/ngfringtoneplugin.cpp
@@ -122,7 +122,8 @@ void NgfRingtonePlugin::onVoiceCallAdded(AbstractVoiceCallHandler *handler)
 
     QObject::connect(handler, SIGNAL(statusChanged()), SLOT(onVoiceCallStatusChanged()));
     d->currentCall = handler;
-    onVoiceCallStatusChanged();
+    if (d->currentCall->status() != AbstractVoiceCallHandler::STATUS_NULL)
+        onVoiceCallStatusChanged();
 }
 
 void NgfRingtonePlugin::onVoiceCallStatusChanged()


### PR DESCRIPTION
Incoming call status is initially null using telepathy plugin. The status
shouldn't be updated when a call is added if the status is null.

Regression due to eb73012e9a54281ac4705367d5c36c7ad46f86b5
