### PR TITLE
[voicecall-manager] Use systemd Wants instead of Requires for ngf and tonegen

### DIFF
--- a/src/voicecall-manager.service
+++ b/src/voicecall-manager.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Voicecall manager
-Requires=dbus.socket ngfd.service tone-generator.service
+Requires=dbus.socket
+Wants=ngfd.service tone-generator.service
 After=pre-user-session.target
 
 [Service]


### PR DESCRIPTION
Requires is a hard dependency that considers the unit failed if the
dependencies fail. Voicecall should still run if either of these is not
available.
