### PR TITLE
[voicecall] Don't set disconnected status prematurely.

### DIFF
--- a/plugins/providers/telepathy/src/telepathyhandler.cpp
+++ b/plugins/providers/telepathy/src/telepathyhandler.cpp
@@ -271,8 +271,6 @@ void TelepathyHandler::hangup()
                          SIGNAL(finished(Tp::PendingOperation*)),
                          SLOT(onStreamedMediaChannelHangupCallFinished(Tp::PendingOperation*)));
     }
-
-    setStatus(STATUS_DISCONNECTED);
 }
 
 void TelepathyHandler::hold(bool on)
@@ -493,13 +491,10 @@ void TelepathyHandler::onCallChannelHangupCallFinished(Tp::PendingOperation *op)
     {
         WARNING_T(QString("Operation failed: ") + op->errorName() + ": " + op->errorMessage());
         emit this->error(QString("Telepathy Operation Failed: %1 - %2").arg(op->errorName(), op->errorMessage()));
-        this->hangup();
         return;
     }
 
     setStatus(STATUS_DISCONNECTED);
-
-    emit this->invalidated("closed", "user");
 }
 
 void TelepathyHandler::onFarstreamCreateChannelFinished(Tp::PendingOperation *op)
@@ -702,13 +697,10 @@ void TelepathyHandler::onStreamedMediaChannelHangupCallFinished(Tp::PendingOpera
     {
         WARNING_T(QString("Operation failed: ") + op->errorName() + ": " + op->errorMessage());
         emit this->error(QString("Telepathy Operation Failed: %1 - %2").arg(op->errorName(), op->errorMessage()));
-        this->hangup();
         return;
     }
 
     setStatus(STATUS_DISCONNECTED);
-
-    emit this->invalidated("closed", "user");
 }
 
 void TelepathyHandler::onStreamedMediaChannelCallStateChanged(uint, uint state)


### PR DESCRIPTION
Wait for telepathy to tell us that the call has been disconnected
before changing the status.

Don't remove the handler until telepathy invalidates the connection.
