### PR TITLE
[voicecall] Revert "Don't set disconnected status prematurely."

### DIFF
--- a/plugins/providers/telepathy/src/telepathyhandler.cpp
+++ b/plugins/providers/telepathy/src/telepathyhandler.cpp
@@ -271,6 +271,8 @@ void TelepathyHandler::hangup()
                          SIGNAL(finished(Tp::PendingOperation*)),
                          SLOT(onStreamedMediaChannelHangupCallFinished(Tp::PendingOperation*)));
     }
+
+    setStatus(STATUS_DISCONNECTED);
 }
 
 void TelepathyHandler::hold(bool on)
@@ -491,10 +493,13 @@ void TelepathyHandler::onCallChannelHangupCallFinished(Tp::PendingOperation *op)
     {
         WARNING_T(QString("Operation failed: ") + op->errorName() + ": " + op->errorMessage());
         emit this->error(QString("Telepathy Operation Failed: %1 - %2").arg(op->errorName(), op->errorMessage()));
+        this->hangup();
         return;
     }
 
     setStatus(STATUS_DISCONNECTED);
+
+    emit this->invalidated("closed", "user");
 }
 
 void TelepathyHandler::onFarstreamCreateChannelFinished(Tp::PendingOperation *op)
@@ -697,10 +702,13 @@ void TelepathyHandler::onStreamedMediaChannelHangupCallFinished(Tp::PendingOpera
     {
         WARNING_T(QString("Operation failed: ") + op->errorName() + ": " + op->errorMessage());
         emit this->error(QString("Telepathy Operation Failed: %1 - %2").arg(op->errorName(), op->errorMessage()));
+        this->hangup();
         return;
     }
 
     setStatus(STATUS_DISCONNECTED);
+
+    emit this->invalidated("closed", "user");
 }
 
 void TelepathyHandler::onStreamedMediaChannelCallStateChanged(uint, uint state)


### PR DESCRIPTION
This reverts commit ce6f3a386f916ed6860d5f945a094052b4d3df51.

Potentially causing issues on hangup. To be revisited later.
