### PR TITLE
[voicecall] Reduce the DBus overhead of call hander interface.

### DIFF
--- a/lib/src/abstractvoicecallhandler.h
+++ b/lib/src/abstractvoicecallhandler.h
@@ -76,13 +76,13 @@ public:
     QString statusText() const;
 
 Q_SIGNALS:
-    void statusChanged();
-    void lineIdChanged();
-    void startedAtChanged();
-    void durationChanged();
-    void emergencyChanged();
-    void multipartyChanged();
-    void forwardedChanged();
+    void statusChanged(VoiceCallStatus);
+    void lineIdChanged(QString);
+    void startedAtChanged(const QDateTime &);
+    void durationChanged(int);
+    void emergencyChanged(bool);
+    void multipartyChanged(bool);
+    void forwardedChanged(bool);
 
 public Q_SLOTS:
     virtual void answer() = 0;

--- a/lib/src/dbus/voicecallhandlerdbusadapter.cpp
+++ b/lib/src/dbus/voicecallhandlerdbusadapter.cpp
@@ -51,13 +51,13 @@ VoiceCallHandlerDBusAdapter::VoiceCallHandlerDBusAdapter(AbstractVoiceCallHandle
     TRACE
     Q_D(VoiceCallHandlerDBusAdapter);
 
-    QObject::connect(d->handler, SIGNAL(statusChanged()), SIGNAL(statusChanged()));
-    QObject::connect(d->handler, SIGNAL(lineIdChanged()), SIGNAL(lineIdChanged()));
-    QObject::connect(d->handler, SIGNAL(startedAtChanged()), SIGNAL(startedAtChanged()));
-    QObject::connect(d->handler, SIGNAL(durationChanged()), SIGNAL(durationChanged()));
-    QObject::connect(d->handler, SIGNAL(emergencyChanged()), SIGNAL(emergencyChanged()));
-    QObject::connect(d->handler, SIGNAL(multipartyChanged()), SIGNAL(multipartyChanged()));
-    QObject::connect(d->handler, SIGNAL(forwardedChanged()), SIGNAL(forwardedChanged()));
+    QObject::connect(d->handler, SIGNAL(statusChanged(VoiceCallStatus)), SLOT(onStatusChanged()));
+    QObject::connect(d->handler, SIGNAL(lineIdChanged(QString)), SIGNAL(lineIdChanged(QString)));
+    QObject::connect(d->handler, SIGNAL(startedAtChanged(QDateTime)), SIGNAL(startedAtChanged(QDateTime)));
+    QObject::connect(d->handler, SIGNAL(durationChanged(int)), SIGNAL(durationChanged(int)));
+    QObject::connect(d->handler, SIGNAL(emergencyChanged(bool)), SIGNAL(emergencyChanged(bool)));
+    QObject::connect(d->handler, SIGNAL(multipartyChanged(bool)), SIGNAL(multipartyChanged(bool)));
+    QObject::connect(d->handler, SIGNAL(forwardedChanged(bool)), SIGNAL(forwardedChanged(bool)));
 }
 
 VoiceCallHandlerDBusAdapter::~VoiceCallHandlerDBusAdapter()
@@ -235,4 +235,30 @@ void VoiceCallHandlerDBusAdapter::sendDtmf(const QString &tones)
     TRACE
     Q_D(VoiceCallHandlerDBusAdapter);
     d->handler->sendDtmf(tones);
+}
+
+QVariantMap VoiceCallHandlerDBusAdapter::getProperties()
+{
+    TRACE
+    Q_D(VoiceCallHandlerDBusAdapter);
+    QVariantMap props;
+
+    props.insert("handlerId", QVariant(handlerId()));
+    props.insert("providerId", QVariant(providerId()));
+    props.insert("status", QVariant(status()));
+    props.insert("statusText", QVariant(statusText()));
+    props.insert("lineId", QVariant(lineId()));
+    props.insert("startedAt", QVariant(startedAt().toMSecsSinceEpoch()));
+    props.insert("duration", QVariant(duration()));
+    props.insert("isIncoming", QVariant(isIncoming()));
+    props.insert("isEmergency", QVariant(isEmergency()));
+    props.insert("isMultiparty", QVariant(isMultiparty()));
+    props.insert("isForwarded", QVariant(isForwarded()));
+
+    return props;
+}
+
+void VoiceCallHandlerDBusAdapter::onStatusChanged()
+{
+    emit statusChanged(status(), statusText());
 }

--- a/lib/src/dbus/voicecallhandlerdbusadapter.h
+++ b/lib/src/dbus/voicecallhandlerdbusadapter.h
@@ -61,13 +61,13 @@ public:
 
 Q_SIGNALS:
     void error(const QString &message);
-    void statusChanged();
-    void lineIdChanged();
-    void startedAtChanged();
-    void durationChanged();
-    void emergencyChanged();
-    void multipartyChanged();
-    void forwardedChanged();
+    void statusChanged(int,QString);
+    void lineIdChanged(QString);
+    void startedAtChanged(const QDateTime &);
+    void durationChanged(int);
+    void emergencyChanged(bool);
+    void multipartyChanged(bool);
+    void forwardedChanged(bool);
 
 public Q_SLOTS:
     bool answer();
@@ -75,6 +75,10 @@ public Q_SLOTS:
     bool hold(bool on);
     bool deflect(const QString &target);
     void sendDtmf(const QString &tones);
+    QVariantMap getProperties();
+
+private Q_SLOTS:
+    void onStatusChanged();
 
 protected:
     VoiceCallHandlerDBusAdapter(class VoiceCallHandlerDBusAdapterPrivate &d, AbstractVoiceCallHandler *parent = 0)

--- a/plugins/declarative/src/voicecallhandler.h
+++ b/plugins/declarative/src/voicecallhandler.h
@@ -23,6 +23,7 @@ class VoiceCallHandler : public QObject
     Q_PROPERTY(bool isEmergency READ isEmergency NOTIFY emergencyChanged)
     Q_PROPERTY(bool isMultiparty READ isMultiparty NOTIFY multipartyChanged)
     Q_PROPERTY(bool isForwarded READ isForwarded NOTIFY forwardedChanged)
+    Q_PROPERTY(bool isReady READ isReady NOTIFY isReadyChanged)
 
 public:
     enum VoiceCallStatus {
@@ -50,6 +51,7 @@ public:
     bool isMultiparty() const;
     bool isEmergency() const;
     bool isForwarded() const;
+    bool isReady() const;
 
 Q_SIGNALS:
     void error(const QString &error);
@@ -60,6 +62,7 @@ Q_SIGNALS:
     void emergencyChanged();
     void multipartyChanged();
     void forwardedChanged();
+    void isReadyChanged();
 
 public Q_SLOTS:
     void answer();
@@ -72,6 +75,13 @@ protected Q_SLOTS:
     void initialize(bool notifyError = false);
 
     void onPendingCallFinished(QDBusPendingCallWatcher *watcher);
+    void onDurationChanged(int duration);
+    void onStatusChanged(int status, const QString &statusText);
+    void onLineIdChanged(const QString &lineId);
+    void onStartedAtChanged(const QDateTime &startedAt);
+    void onEmergencyChanged(bool emergency);
+    void onMultipartyChanged(bool multiparty);
+    void onForwardedChanged(bool forwarded);
 
 private:
     class VoiceCallHandlerPrivate *d_ptr;

--- a/plugins/ngf/src/ngfringtoneplugin.cpp
+++ b/plugins/ngf/src/ngfringtoneplugin.cpp
@@ -124,7 +124,7 @@ void NgfRingtonePlugin::onVoiceCallAdded(AbstractVoiceCallHandler *handler)
     ++d->activeCallCount;
     DEBUG_T(QString("Active call count: %1").arg(d->activeCallCount));
 
-    QObject::connect(handler, SIGNAL(statusChanged()), SLOT(onVoiceCallStatusChanged()));
+    QObject::connect(handler, SIGNAL(statusChanged(VoiceCallStatus)), SLOT(onVoiceCallStatusChanged()));
     QObject::connect(handler, SIGNAL(destroyed()), SLOT(onVoiceCallDestroyed()));
     if (handler->status() != AbstractVoiceCallHandler::STATUS_NULL)
         onVoiceCallStatusChanged(handler);

--- a/plugins/providers/ofono/src/ofonovoicecallhandler.cpp
+++ b/plugins/providers/ofono/src/ofonovoicecallhandler.cpp
@@ -62,10 +62,9 @@ OfonoVoiceCallHandler::OfonoVoiceCallHandler(const QString &handlerId, const QSt
     d->ofonoVoiceCall->setVoiceCallPath(path);
     d->isIncoming = d->ofonoVoiceCall->state() == QLatin1String("incoming");
 
-    QObject::connect(d->ofonoVoiceCall, SIGNAL(stateChanged(QString)), SIGNAL(statusChanged()));
-    QObject::connect(d->ofonoVoiceCall, SIGNAL(lineIdentificationChanged(QString)), SIGNAL(lineIdChanged()));
-    QObject::connect(d->ofonoVoiceCall, SIGNAL(emergencyChanged(bool)), SIGNAL(emergencyChanged()));
-    QObject::connect(d->ofonoVoiceCall, SIGNAL(multipartyChanged(bool)), SIGNAL(multipartyChanged()));
+    QObject::connect(d->ofonoVoiceCall, SIGNAL(lineIdentificationChanged(QString)), SIGNAL(lineIdChanged(QString)));
+    QObject::connect(d->ofonoVoiceCall, SIGNAL(emergencyChanged(bool)), SIGNAL(emergencyChanged(bool)));
+    QObject::connect(d->ofonoVoiceCall, SIGNAL(multipartyChanged(bool)), SIGNAL(multipartyChanged(bool)));
 
     QObject::connect(d->ofonoVoiceCall, SIGNAL(stateChanged(QString)), SLOT(onStatusChanged()));
 
@@ -226,7 +225,7 @@ void OfonoVoiceCallHandler::timerEvent(QTimerEvent *event)
     if(isOngoing() && event->timerId() == d->durationTimerId)
     {
         d->duration += d->elapsedTimer.restart();
-        emit this->durationChanged();
+        emit this->durationChanged(d->duration);
     }
 }
 
@@ -247,4 +246,6 @@ void OfonoVoiceCallHandler::onStatusChanged()
         this->killTimer(d->durationTimerId);
         d->durationTimerId = -1;
     }
+
+    emit statusChanged(status());
 }

--- a/src/audiocallpolicyproxy.cpp
+++ b/src/audiocallpolicyproxy.cpp
@@ -46,9 +46,9 @@ AudioCallPolicyProxy::AudioCallPolicyProxy(AbstractVoiceCallHandler *subject, QO
     : AbstractVoiceCallHandler(parent), d_ptr(new AudioCallPolicyProxyPrivate(this, subject))
 {
     TRACE
-    QObject::connect(subject, SIGNAL(statusChanged()), SIGNAL(statusChanged()));
-    QObject::connect(subject, SIGNAL(lineIdChanged()), SIGNAL(lineIdChanged()));
-    QObject::connect(subject, SIGNAL(durationChanged()), SIGNAL(durationChanged()));
+    QObject::connect(subject, SIGNAL(statusChanged(VoiceCallStatus)), SIGNAL(statusChanged(VoiceCallStatus)));
+    QObject::connect(subject, SIGNAL(lineIdChanged(QString)), SIGNAL(lineIdChanged(QString)));
+    QObject::connect(subject, SIGNAL(durationChanged(int)), SIGNAL(durationChanged(int)));
     QObject::connect(subject, SIGNAL(emergencyChanged()), SIGNAL(emergencyChanged()));
     QObject::connect(subject, SIGNAL(multipartyChanged()), SIGNAL(multipartyChanged()));
 }

--- a/src/basicringtonenotificationprovider.cpp
+++ b/src/basicringtonenotificationprovider.cpp
@@ -134,7 +134,7 @@ void BasicRingtoneNotificationProvider::onVoiceCallAdded(AbstractVoiceCallHandle
     TRACE
     Q_D(BasicRingtoneNotificationProvider);
 
-    QObject::connect(handler, SIGNAL(statusChanged()), SLOT(onVoiceCallStatusChanged()));
+    QObject::connect(handler, SIGNAL(statusChanged(VoiceCallStatus)), SLOT(onVoiceCallStatusChanged()));
     d->currentCall = handler;
 }
 
@@ -146,7 +146,7 @@ void BasicRingtoneNotificationProvider::onVoiceCallStatusChanged()
     if(d->currentCall->status() != AbstractVoiceCallHandler::STATUS_INCOMING)
     {
         DEBUG_T("Disconnecting from handler.");
-        QObject::disconnect(d->currentCall, SIGNAL(statusChanged()), this, SLOT(onVoiceCallStatusChanged()));
+        QObject::disconnect(d->currentCall, SIGNAL(statusChanged(VoiceCallStatus)), this, SLOT(onVoiceCallStatusChanged()));
 
         d->player->stop();
         d->player->setPosition(0);


### PR DESCRIPTION
The declarative plugin provides properties of a call by via a
synchronous call every time the property is accessed. In QML this can
happen _very_ often.

Cache the properties on the client side, and provide property values in
change signals to eliminate the blocking calls.
