### PR TITLE
[voicecall] Don't set disconnected status prematurely.

### DIFF
--- a/plugins/providers/telepathy/src/telepathyhandler.cpp
+++ b/plugins/providers/telepathy/src/telepathyhandler.cpp
@@ -293,8 +293,6 @@ void TelepathyHandler::hangup()
                          SIGNAL(finished(Tp::PendingOperation*)),
                          SLOT(onStreamedMediaChannelHangupCallFinished(Tp::PendingOperation*)));
     }
-
-    setStatus(STATUS_DISCONNECTED);
 }
 
 void TelepathyHandler::hold(bool on)
@@ -520,8 +518,6 @@ void TelepathyHandler::onCallChannelHangupCallFinished(Tp::PendingOperation *op)
     }
 
     setStatus(STATUS_DISCONNECTED);
-
-    emit this->invalidated("closed", "user");
 }
 
 void TelepathyHandler::onFarstreamCreateChannelFinished(Tp::PendingOperation *op)
@@ -729,8 +725,6 @@ void TelepathyHandler::onStreamedMediaChannelHangupCallFinished(Tp::PendingOpera
     }
 
     setStatus(STATUS_DISCONNECTED);
-
-    emit this->invalidated("closed", "user");
 }
 
 void TelepathyHandler::onStreamedMediaChannelCallStateChanged(uint, uint state)


### PR DESCRIPTION
Wait for telepathy to tell us that the call has been disconnected
before changing the status.

Don't remove the handler until telepathy invalidates the connection.

This is a partial restortion of ce6f3a386f916ed6860d5f945a094052b4d3df51