### PR TITLE
[voicecall] Force critical telepathy accounts back online immediately on failure

### DIFF
--- a/plugins/providers/telepathy/src/telepathyprovider.cpp
+++ b/plugins/providers/telepathy/src/telepathyprovider.cpp
@@ -48,6 +48,8 @@ public:
     QHash<QString,AbstractVoiceCallHandler*> voiceCalls;
 
     Tp::PendingChannelRequest *tpChannelRequest;
+
+    bool shouldForceReconnect() const;
 };
 
 TelepathyProvider::TelepathyProvider(Tp::AccountPtr account, VoiceCallManagerInterface *manager, QObject *parent)
@@ -159,6 +161,12 @@ void TelepathyProvider::onAccountAvailabilityChanged()
     else
     {
         d->manager->removeProvider(this);
+
+        if (d->shouldForceReconnect())
+        {
+            WARNING_T(QString("Forcing account %1 back online immediately").arg(d->account.data()->uniqueIdentifier()));
+            d->account->setRequestedPresence(Tp::Presence::available());
+        }
     }
 }
 
@@ -240,4 +248,9 @@ void TelepathyProvider::onHandlerInvalidated(const QString &errorName, const QSt
         d->errorString = QString("Telepathy Handler Invalidated: %1 - %2").arg(errorName, errorMessage);
         emit this->error(d->errorString);
     }
+}
+
+bool TelepathyProviderPrivate::shouldForceReconnect() const
+{
+    return account->cmName() == "ring";
 }


### PR DESCRIPTION
Mission control implements reconnecting logic for accounts, but it has a
fairly severe backoff, because it's tuned for internet-connected
accounts. For telephony, it's very important that we get the account
back up as quickly as possible on failure to avoid missing incoming
traffic.

We can force mission control to reconnect the account instantly by
requesting an available presence immediately after failures. For
example, this causes telepathy-ring to be restarted instantly after
crashing or being killed.
