### PR TITLE
[ngf] Pause when silence is requested.

### DIFF
--- a/plugins/ngf/src/ngfringtoneplugin.cpp
+++ b/plugins/ngf/src/ngfringtoneplugin.cpp
@@ -202,9 +202,8 @@ void NgfRingtonePlugin::onSilenceRingtoneRequested()
     Q_D(NgfRingtonePlugin);
     if (d->ringtoneEventId)
     {
-        DEBUG_T("Stopping ringtone due to silence");
-        d->ngf->stop("ringtone");
-        d->ringtoneEventId = 0;
+        DEBUG_T("Pausing ringtone due to silence");
+        d->ngf->pause("ringtone");
     }
 }
 


### PR DESCRIPTION
It is useful to have the ringtone event active even when the ringtone is
silenced. For that pause instead of stop the ringtone when silence is
requested but don't clear the ringtone's event id, so that the ringtone
is stopped when call is destroyed or changes to active.
