### PR TITLE
[voicecall] add support for remote held signal.Fixes MER#907

### DIFF
--- a/lib/src/abstractvoicecallhandler.h
+++ b/lib/src/abstractvoicecallhandler.h
@@ -43,6 +43,7 @@ class AbstractVoiceCallHandler : public QObject
     Q_PROPERTY(bool isEmergency READ isEmergency NOTIFY emergencyChanged)
     Q_PROPERTY(bool isMultiparty READ isMultiparty NOTIFY multipartyChanged)
     Q_PROPERTY(bool isForwarded READ isForwarded NOTIFY forwardedChanged)
+    Q_PROPERTY(bool isRemoteHeld READ isRemoteHeld NOTIFY remoteHeldChanged)
 
 public:
     enum VoiceCallStatus {
@@ -69,6 +70,7 @@ public:
     virtual bool isMultiparty() const = 0;
     virtual bool isEmergency() const = 0;
     virtual bool isForwarded() const = 0;
+    virtual bool isRemoteHeld() const = 0;
 
     virtual VoiceCallStatus status() const = 0;
 
@@ -83,6 +85,7 @@ Q_SIGNALS:
     void emergencyChanged(bool);
     void multipartyChanged(bool);
     void forwardedChanged(bool);
+    void remoteHeldChanged(bool);
 
 public Q_SLOTS:
     virtual void answer() = 0;

--- a/lib/src/dbus/voicecallhandlerdbusadapter.cpp
+++ b/lib/src/dbus/voicecallhandlerdbusadapter.cpp
@@ -58,6 +58,7 @@ VoiceCallHandlerDBusAdapter::VoiceCallHandlerDBusAdapter(AbstractVoiceCallHandle
     QObject::connect(d->handler, SIGNAL(emergencyChanged(bool)), SIGNAL(emergencyChanged(bool)));
     QObject::connect(d->handler, SIGNAL(multipartyChanged(bool)), SIGNAL(multipartyChanged(bool)));
     QObject::connect(d->handler, SIGNAL(forwardedChanged(bool)), SIGNAL(forwardedChanged(bool)));
+    QObject::connect(d->handler, SIGNAL(remoteHeldChanged(bool)), SIGNAL(remoteHeldChanged(bool)));
 }
 
 VoiceCallHandlerDBusAdapter::~VoiceCallHandlerDBusAdapter()
@@ -146,6 +147,16 @@ bool VoiceCallHandlerDBusAdapter::isForwarded() const
     TRACE
     Q_D(const VoiceCallHandlerDBusAdapter);
     return d->handler->isForwarded();
+}
+
+/*!
+  Returns this voice calls' remote held flag property.
+*/
+bool VoiceCallHandlerDBusAdapter::isRemoteHeld() const
+{
+    TRACE
+    Q_D(const VoiceCallHandlerDBusAdapter);
+    return d->handler->isRemoteHeld();
 }
 
 /*!
@@ -254,6 +265,7 @@ QVariantMap VoiceCallHandlerDBusAdapter::getProperties()
     props.insert("isEmergency", QVariant(isEmergency()));
     props.insert("isMultiparty", QVariant(isMultiparty()));
     props.insert("isForwarded", QVariant(isForwarded()));
+    props.insert("isRemoteHeld", QVariant(isRemoteHeld()));
 
     return props;
 }

--- a/lib/src/dbus/voicecallhandlerdbusadapter.h
+++ b/lib/src/dbus/voicecallhandlerdbusadapter.h
@@ -42,6 +42,7 @@ class VoiceCallHandlerDBusAdapter : public QDBusAbstractAdaptor
     Q_PROPERTY(bool isEmergency READ isEmergency NOTIFY emergencyChanged)
     Q_PROPERTY(bool isMultiparty READ isMultiparty NOTIFY multipartyChanged)
     Q_PROPERTY(bool isForwarded READ isForwarded NOTIFY forwardedChanged)
+    Q_PROPERTY(bool isRemoteHeld READ isRemoteHeld NOTIFY remoteHeldChanged)
 
 public:
     explicit VoiceCallHandlerDBusAdapter(AbstractVoiceCallHandler *parent = 0);
@@ -58,6 +59,7 @@ public:
     bool isMultiparty() const;
     bool isEmergency() const;
     bool isForwarded() const;
+    bool isRemoteHeld() const;
 
 Q_SIGNALS:
     void error(const QString &message);
@@ -68,6 +70,7 @@ Q_SIGNALS:
     void emergencyChanged(bool);
     void multipartyChanged(bool);
     void forwardedChanged(bool);
+    void remoteHeldChanged(bool);
 
 public Q_SLOTS:
     bool answer();

--- a/plugins/declarative/src/voicecallhandler.h
+++ b/plugins/declarative/src/voicecallhandler.h
@@ -24,6 +24,7 @@ class VoiceCallHandler : public QObject
     Q_PROPERTY(bool isMultiparty READ isMultiparty NOTIFY multipartyChanged)
     Q_PROPERTY(bool isForwarded READ isForwarded NOTIFY forwardedChanged)
     Q_PROPERTY(bool isReady READ isReady NOTIFY isReadyChanged)
+    Q_PROPERTY(bool isRemoteHeld READ isRemoteHeld NOTIFY remoteHeldChanged)
 
 public:
     enum VoiceCallStatus {
@@ -52,6 +53,7 @@ public:
     bool isEmergency() const;
     bool isForwarded() const;
     bool isReady() const;
+    bool isRemoteHeld() const;
 
 Q_SIGNALS:
     void error(const QString &error);
@@ -63,6 +65,7 @@ Q_SIGNALS:
     void multipartyChanged();
     void forwardedChanged();
     void isReadyChanged();
+    void remoteHeldChanged();
 
 public Q_SLOTS:
     void answer();
@@ -82,6 +85,7 @@ protected Q_SLOTS:
     void onEmergencyChanged(bool emergency);
     void onMultipartyChanged(bool multiparty);
     void onForwardedChanged(bool forwarded);
+    void onRemoteHeldChanged(bool remoteHeld);
 
 private:
     class VoiceCallHandlerPrivate *d_ptr;

--- a/plugins/providers/ofono/src/ofonovoicecallhandler.cpp
+++ b/plugins/providers/ofono/src/ofonovoicecallhandler.cpp
@@ -149,6 +149,12 @@ bool OfonoVoiceCallHandler::isForwarded() const
     return false;
 }
 
+bool OfonoVoiceCallHandler::isRemoteHeld() const
+{
+    TRACE
+    return false;
+}
+
 AbstractVoiceCallHandler::VoiceCallStatus OfonoVoiceCallHandler::status() const
 {
     TRACE

--- a/plugins/providers/ofono/src/ofonovoicecallhandler.h
+++ b/plugins/providers/ofono/src/ofonovoicecallhandler.h
@@ -48,6 +48,7 @@ public:
     bool isMultiparty() const;
     bool isEmergency() const;
     bool isForwarded() const;
+    bool isRemoteHeld() const;
 
     VoiceCallStatus status() const;
 

--- a/plugins/providers/telepathy/src/callchannelhandler.cpp
+++ b/plugins/providers/telepathy/src/callchannelhandler.cpp
@@ -64,7 +64,7 @@ public:
     CallChannelHandlerPrivate(CallChannelHandler *q, const QString &id, Tp::CallChannelPtr c, const QDateTime &s, TelepathyProvider *p)
         : q_ptr(q), handlerId(id), provider(p), startedAt(s), status(AbstractVoiceCallHandler::STATUS_NULL),
           channel(c), fsChannel(NULL), duration(0), durationTimerId(-1), isEmergency(false),
-          isForwarded(false), isIncoming(false)
+          isForwarded(false), isIncoming(false), isRemoteHeld(false)
     { /* ... */ }
 
     CallChannelHandler  *q_ptr;
@@ -86,6 +86,7 @@ public:
     bool isEmergency;
     bool isForwarded;
     bool isIncoming;
+    bool isRemoteHeld;
 };
 
 CallChannelHandler::CallChannelHandler(const QString &id, Tp::CallChannelPtr channel, const QDateTime &userActionTime, TelepathyProvider *provider)
@@ -178,6 +179,14 @@ bool CallChannelHandler::isForwarded() const
     Q_D(const CallChannelHandler);
     if(!d->channel->isReady()) return false;
     return d->isForwarded;
+}
+
+bool CallChannelHandler::isRemoteHeld() const
+{
+    TRACE
+    Q_D(const CallChannelHandler);
+    if(!d->channel->isReady()) return false;
+    return d->isRemoteHeld;
 }
 
 AbstractVoiceCallHandler::VoiceCallStatus CallChannelHandler::status() const

--- a/plugins/providers/telepathy/src/callchannelhandler.h
+++ b/plugins/providers/telepathy/src/callchannelhandler.h
@@ -46,6 +46,7 @@ public:
     bool isMultiparty() const;
     bool isEmergency() const;
     bool isForwarded() const;
+    bool isRemoteHeld() const;
 
     VoiceCallStatus status() const;
 

--- a/plugins/providers/telepathy/src/streamchannelhandler.h
+++ b/plugins/providers/telepathy/src/streamchannelhandler.h
@@ -45,6 +45,7 @@ public:
     bool isMultiparty() const;
     bool isEmergency() const;
     bool isForwarded() const;
+    bool isRemoteHeld() const;
 
     VoiceCallStatus status() const;
 


### PR DESCRIPTION
Adds support for indicating if the remote end put call on hold. Implements support only for telepathy stream channel.

Signed-off-by: Jarko Poutiainen <jarko.poutiainen@oss.tieto.com>